### PR TITLE
Remove License Check from Qodana

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -21,5 +21,3 @@ profile:
 #  - id: <plugin.id> #(plugin id can be found at https://plugins.jetbrains.com)
 #Specify Qodana linter for analysis (Applied in CI/CD pipeline)
 linter: jetbrains/qodana-python:latest
-include:
-  - name: CheckDependencyLicenses


### PR DESCRIPTION
This change is made to move from a trial license to a community license on qodana